### PR TITLE
Fixed missing SFC_SET_SCALE_INT_FLOAT_WRITE

### DIFF
--- a/LONG_DESCR
+++ b/LONG_DESCR
@@ -105,6 +105,11 @@ Please see the developer documentation
 Changes
 -------
 
+Version\_1.3.2.1 (2019-05-30)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Fixed missing SFC_SET_SCALE_INT_FLOAT_WRITE command
+
 Version\_1.3.2 (2018-07-04)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Please see the developer documentation [here](https://pysndfile.readthedocs.io/e
 
 ## Changes
 
+### Version_1.3.2.1 (2019-05-30)
+
+ * Fixed missing SFC_SET_SCALE_INT_FLOAT_WRITE command
+
 ### Version_1.3.2 (2018-07-04)
 
  * fixed documentation of sndio module.

--- a/_pysndfile.pyx
+++ b/_pysndfile.pyx
@@ -31,7 +31,7 @@ import os
 cimport numpy as cnp
 from libcpp.string cimport string
 
-_pysndfile_version=(1,3,2)
+_pysndfile_version=(1,3,2,1)
 def get_pysndfile_version():
     """
     return tuple describing the version opf pysndfile
@@ -175,6 +175,7 @@ cdef extern from "pysndfile.hh":
     cdef int C_SFC_SET_NORM_DOUBLE "SFC_SET_NORM_DOUBLE"  
     cdef int C_SFC_SET_NORM_FLOAT "SFC_SET_NORM_FLOAT"  
     cdef int C_SFC_SET_SCALE_FLOAT_INT_READ "SFC_SET_SCALE_FLOAT_INT_READ"  
+    cdef int C_SFC_SET_SCALE_INT_FLOAT_WRITE "SFC_SET_SCALE_INT_FLOAT_WRITE"  
 
     cdef int C_SFC_GET_SIMPLE_FORMAT_COUNT "SFC_GET_SIMPLE_FORMAT_COUNT"  
     cdef int C_SFC_GET_SIMPLE_FORMAT "SFC_GET_SIMPLE_FORMAT"  
@@ -368,6 +369,7 @@ _commands_to_id_tuple = (
     ("SFC_SET_NORM_DOUBLE" , C_SFC_SET_NORM_DOUBLE),
     ("SFC_SET_NORM_FLOAT" , C_SFC_SET_NORM_FLOAT),
     ("SFC_SET_SCALE_FLOAT_INT_READ" , C_SFC_SET_SCALE_FLOAT_INT_READ),
+    ("SFC_SET_SCALE_INT_FLOAT_WRITE" , C_SFC_SET_SCALE_INT_FLOAT_WRITE),
 
     ("SFC_GET_SIMPLE_FORMAT_COUNT" , C_SFC_GET_SIMPLE_FORMAT_COUNT),
     ("SFC_GET_SIMPLE_FORMAT" , C_SFC_GET_SIMPLE_FORMAT),

--- a/doc/source/Changes.rst
+++ b/doc/source/Changes.rst
@@ -1,6 +1,11 @@
 Changes
 -------
 
+Version\_1.3.2.1 (2019-05-30)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Fixed missing SFC_SET_SCALE_INT_FLOAT_WRITE command
+
 Version\_1.3.2 (2018-07-04)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The SFC_SET_SCALE_INT_FLOAT_WRITE command is missing from the exposed pysndfile interface.

This feature branch also changes the pysndfile version, which is probably not wanted in the same way in the main release.
